### PR TITLE
Allow multiple channels in backend

### DIFF
--- a/na-backend/js/lib/server-setup.js
+++ b/na-backend/js/lib/server-setup.js
@@ -1,26 +1,34 @@
 export function setupClients() {
-    const clients = [];
+    const clients = {};
     return {
-        add: function(client) {
-            clients.push(client);
+        addToChannel: function(client, channel) {
+            if (clients[channel]) {
+                clients[channel].push(client);
+            } else {
+                clients[channel] = [client];
+            }
         },
         count: function() {
-            return clients.length;
+            const clientCount = {};
+            Object.keys(clients).forEach(channel => {
+                clientCount[channel] = clients[channel].length;
+            });
+            return clientCount;
         },
-        writeToAll: function(data) {
-            clients.forEach(client => {
+        writeToAllForChannel: function(data, channel) {
+            clients[channel].forEach(client => {
                 client.res.write(data);
             });
         },
-        removeByIp: function(ip) {
+        removeByIpFromChannel: function(ip, channel) {
             const indices = [];
-            clients.forEach((client, i) => {
+            clients[channel].forEach((client, i) => {
                 if (client.ip === ip) {
                     indices.push(i);
                 }
             });
             indices.forEach(i => {
-                clients.splice(i, 1);
+                clients[channel].splice(i, 1);
             });
         },
         get: function() {

--- a/na-backend/js/lib/setup-stream-handler.js
+++ b/na-backend/js/lib/setup-stream-handler.js
@@ -14,7 +14,8 @@ export default function(clients, streamers, updateTrackListing, nextSongInQueue)
         const trackEnd = streamedData
             .filter(data => !Buffer.isBuffer(data) && (typeof data === 'string' || data instanceof String));
         trackEnd.subscribe(data => {
-            nextSongInQueue();
+            const channel = data.split(';')[1];
+            nextSongInQueue(channel);
         });
 
         const binaryData = streamedData

--- a/na-backend/js/queries/channel.js
+++ b/na-backend/js/queries/channel.js
@@ -1,0 +1,18 @@
+export function listChannels(db) {
+    return db.query('select * from Channel')
+    .then(results => {
+        return results.map(result => ({key: result.key, title: result.title}));
+    });
+}
+
+export function createChannelQuery(db, title, key) {
+    return db.query(`insert into Channel (title, key) values (${title}, ${key})`);
+}
+
+export function deleteChannelQuery(db, key) {
+    return db.query('delete vertex from Channel where key = :key', {
+        params: {
+            key: key
+        }
+    });
+}

--- a/na-backend/js/queries/now-playing.js
+++ b/na-backend/js/queries/now-playing.js
@@ -1,0 +1,15 @@
+export default function(db, channel) {
+    return db.query('select from Now_Playing where channel = :channel limit 1', {
+        params: {
+            channel: channel
+        }
+    })
+    .then(results => {
+        const nowPlaying = results[0];
+        return {
+            title: nowPlaying.title,
+            album: nowPlaying.album,
+            artist: nowPlaying.artist
+        };
+    });
+}

--- a/na-backend/js/queries/queue.js
+++ b/na-backend/js/queries/queue.js
@@ -1,0 +1,40 @@
+export function listQueueForChannel(db, channel='default') {
+    return db.query('select * from Queue where channel = :channel', {
+        params: {
+            channel: channel
+        }
+    })
+    .then(results => {
+        return results.map(result => result.id);
+    })
+    .then(rids => {
+        if (rids.length) {
+            return db.query(`select *, out('Found_On').title as album, out('Found_On').out('Recorded_By').name as artist from [${rids}]`);
+        }
+        return [];
+    })
+    .then(results => {
+        return results.map(result => {
+            return {
+                title: result.title,
+                id: result.id,
+                album: result.album[0],
+                artist: result.artist[0],
+                rid: result['@rid']
+            };
+        });
+    });
+}
+
+export function addToChannelQueue(db, rid, channel='default') {
+    return db.query(`insert into Queue (id, channel) values (${rid}, ${channel})`);
+}
+
+export function removeFromChannelQueue(db, rid, channel='default') {
+    return db.query('delete vertex from Queue where id = :rid and channel = :channel', {
+        params: {
+            rid: rid,
+            channel: channel
+        }
+    });
+}

--- a/na-backend/js/routes/channel.js
+++ b/na-backend/js/routes/channel.js
@@ -1,0 +1,39 @@
+import uuid from 'node-uuid';
+
+export const getChannels = {
+    url: '/api/channel',
+    generateHandler: function(db, listChannels) {
+        return function(req, res) {
+            return listChannels(db)
+            .then(results => {
+                res.send(JSON.stringify(results));
+            });
+        };
+    }
+}
+
+export const createChannel = {
+    url: '/api/channel',
+    generateHandler: function(db, create) {
+        return function(req, res) {
+            const key = uuid.v4().substring(0, 6);
+            console.log(key, typeof key);
+            return create(db, req.body.title, key)
+            .then(() => {
+                res.sendStatus(200);
+            });
+        };
+    }
+}
+
+export const deleteChannel = {
+    url: '/api/channel/:key',
+    generateHandler: function(db, deleteQuery) {
+        return function(req, res) {
+            return deleteQuery(db, req.params.key)
+            .then(() => {
+                res.sendStatus(200);
+            });
+        };
+    }
+}

--- a/na-backend/js/routes/channel.js
+++ b/na-backend/js/routes/channel.js
@@ -14,11 +14,10 @@ export const getChannels = {
 
 export const createChannel = {
     url: '/api/channel',
-    generateHandler: function(db, create) {
+    generateHandler: function(db, createQuery) {
         return function(req, res) {
             const key = uuid.v4().substring(0, 6);
-            console.log(key, typeof key);
-            return create(db, req.body.title, key)
+            return createQuery(db, req.body.title, key)
             .then(() => {
                 res.sendStatus(200);
             });

--- a/na-backend/js/routes/now-playing.js
+++ b/na-backend/js/routes/now-playing.js
@@ -1,16 +1,8 @@
 export const getNowPlaying = {
-    url: '/api/playing',
-    generateHandler: function(db) {
+    url: '/api/playing/:channel',
+    generateHandler: function(db, nowPlayingQuery) {
         return function(req, res) {
-            return db.query('select from Now_Playing limit 1')
-            .then(results => {
-                const nowPlaying = results[0];
-                return {
-                    title: nowPlaying.title,
-                    album: nowPlaying.album,
-                    artist: nowPlaying.artist
-                };
-            })
+            return nowPlayingQuery(db, req.params.channel)
             .then(nowPlaying => {
                 res.status(200).send(JSON.stringify(nowPlaying));
             });

--- a/na-backend/js/routes/queue.js
+++ b/na-backend/js/routes/queue.js
@@ -1,28 +1,8 @@
 export const getQueue = {
-    url: '/api/queue',
-    generateHandler: function(db) {
+    url: '/api/queue/:channel',
+    generateHandler: function(db, listQueueForChannel) {
         return function(req, res) {
-            return db.query('select * from Queue')
-            .then(results => {
-                return results.map(result => result.id);
-            })
-            .then(rids => {
-                if (rids.length) {
-                    return db.query(`select *, out('Found_On').title as album, out('Found_On').out('Recorded_By').name as artist from [${rids}]`);
-                }
-                return [];
-            })
-            .then(results => {
-                return results.map(result => {
-                    return {
-                        title: result.title,
-                        id: result.id,
-                        album: result.album[0],
-                        artist: result.artist[0],
-                        rid: result['@rid']
-                    };
-                });
-            })
+            return listQueueForChannel(db, req.params.channel)
             .then(results => {
                 res.send(JSON.stringify(results));
             });
@@ -31,11 +11,10 @@ export const getQueue = {
 }
 
 export const addToQueue = {
-    url: '/api/queue',
-    generateHandler: function(db) {
+    url: '/api/queue/:channel',
+    generateHandler: function(db, addToChannelQueue) {
         return function(req, res) {
-            const rid = req.body.rid;
-            return db.query(`insert into Queue (id) values (${rid})`)
+            return addToChannelQueue(db, req.body.rid, req.params.channel)
             .then(() => {
                 res.sendStatus(200);
             });
@@ -44,15 +23,10 @@ export const addToQueue = {
 }
 
 export const removeFromQueue = {
-    url: '/api/queue',
-    generateHandler: function(db) {
+    url: '/api/queue/:channel',
+    generateHandler: function(db, removeFromChannelQueue) {
         return function(req, res) {
-            const rid = req.body.rid;
-            return db.query('delete vertex from Queue where id = :rid', {
-                params: {
-                    rid: rid
-                }
-            })
+            return removeFromChannelQueue(db, req.body.rid, req.params.channel)
             .then(() => {
                 res.sendStatus(200);
             });

--- a/na-backend/js/routes/routes-setup.js
+++ b/na-backend/js/routes/routes-setup.js
@@ -6,6 +6,7 @@ import {getQueue, addToQueue, removeFromQueue} from './queue';
 import {getClients} from './clients';
 import {getNowPlaying} from './now-playing';
 import {getChannels, createChannel, deleteChannel} from './channel';
+import nowPlayingQuery from '../queries/now-playing';
 
 import {listQueueForChannel, addToChannelQueue, removeFromChannelQueue}
     from '../queries/queue';
@@ -20,7 +21,7 @@ export default function(app, db, clients, populateQueue) {
     app.get(getSongs.url, getSongs.generateHandler(db));
     app.get(getQueue.url, getQueue.generateHandler(db, listQueueForChannel));
     app.get(getClients.url, getClients.generateHandler(clients));
-    app.get(getNowPlaying.url, getNowPlaying.generateHandler(db));
+    app.get(getNowPlaying.url, getNowPlaying.generateHandler(db, nowPlayingQuery));
     app.get(getChannels.url, getChannels.generateHandler(db, listChannels));
 
     app.post(addToQueue.url, addToQueue.generateHandler(db, addToChannelQueue));

--- a/na-backend/js/routes/routes-setup.js
+++ b/na-backend/js/routes/routes-setup.js
@@ -6,6 +6,9 @@ import {getQueue, addToQueue, removeFromQueue} from './queue';
 import {getClients} from './clients';
 import {getNowPlaying} from './now-playing';
 
+import {listQueueForChannel, addToChannelQueue, removeFromChannelQueue}
+    from '../queries/queue';
+
 export default function(app, db, clients, populateQueue) {
     app.use(bodyParser.json());
 
@@ -13,11 +16,11 @@ export default function(app, db, clients, populateQueue) {
     app.get(getArtists.url, getArtists.generateHandler(db));
     app.get(getAlbums.url, getAlbums.generateHandler(db));
     app.get(getSongs.url, getSongs.generateHandler(db));
-    app.get(getQueue.url, getQueue.generateHandler(db));
+    app.get(getQueue.url, getQueue.generateHandler(db, listQueueForChannel));
     app.get(getClients.url, getClients.generateHandler(clients));
     app.get(getNowPlaying.url, getNowPlaying.generateHandler(db));
 
-    app.post(addToQueue.url, addToQueue.generateHandler(db));
+    app.post(addToQueue.url, addToQueue.generateHandler(db, addToChannelQueue));
 
-    app.delete(removeFromQueue.url, removeFromQueue.generateHandler(db));
+    app.delete(removeFromQueue.url, removeFromQueue.generateHandler(db, removeFromChannelQueue));
 }

--- a/na-backend/js/routes/routes-setup.js
+++ b/na-backend/js/routes/routes-setup.js
@@ -5,9 +5,11 @@ import {getArtists, getAlbums, getSongs} from './library';
 import {getQueue, addToQueue, removeFromQueue} from './queue';
 import {getClients} from './clients';
 import {getNowPlaying} from './now-playing';
+import {getChannels, createChannel, deleteChannel} from './channel';
 
 import {listQueueForChannel, addToChannelQueue, removeFromChannelQueue}
     from '../queries/queue';
+import {listChannels, createChannelQuery, deleteChannelQuery} from '../queries/channel';
 
 export default function(app, db, clients, populateQueue) {
     app.use(bodyParser.json());
@@ -19,8 +21,11 @@ export default function(app, db, clients, populateQueue) {
     app.get(getQueue.url, getQueue.generateHandler(db, listQueueForChannel));
     app.get(getClients.url, getClients.generateHandler(clients));
     app.get(getNowPlaying.url, getNowPlaying.generateHandler(db));
+    app.get(getChannels.url, getChannels.generateHandler(db, listChannels));
 
     app.post(addToQueue.url, addToQueue.generateHandler(db, addToChannelQueue));
+    app.post(createChannel.url, createChannel.generateHandler(db, createChannelQuery));
 
     app.delete(removeFromQueue.url, removeFromQueue.generateHandler(db, removeFromChannelQueue));
+    app.delete(deleteChannel.url, deleteChannel.generateHandler(db, deleteChannelQuery));
 }

--- a/na-backend/js/routes/stream.js
+++ b/na-backend/js/routes/stream.js
@@ -1,6 +1,6 @@
 export const getStream = {
-    url: '/api/stream',
-    generateHandler: function(clients, populateQueue) {
+    url: '/api/stream/:channel',
+    generateHandler: function(clients, populateQueueForChannel) {
         return function(req, res) {
             const headers = {
                 "Content-Type": "audio/mpeg",
@@ -10,14 +10,15 @@ export const getStream = {
             if (!res.headers) {
                 res.writeHead(200, headers);
             }
-            clients.add({
+            clients.addToChannel({
                 ip: req.ip,
                 res: res
-            });
-            populateQueue();
+            }, req.params.channel);
+
+            populateQueueForChannel(req.params.channel);
 
             req.connection.on('close', () => {
-                clients.removeByIp(req.ip);
+                clients.removeByIpFromChannel(req.ip, req.params.channel);
             });
         };
     }

--- a/na-backend/migrations/m20160731_123915_add_channel.js
+++ b/na-backend/migrations/m20160731_123915_add_channel.js
@@ -1,0 +1,19 @@
+"use strict";
+exports.name = "add channel";
+
+exports.up = function (db) {
+    db.class.create('Channel', 'V').then(Channel => {
+        Channel.property.create({
+            name: 'title',
+            type: 'String'
+        });
+        Channel.property.create({
+            name: 'key',
+            type: 'String'
+        });
+    });
+};
+
+exports.down = function (db) {
+    db.query('drop class Channel');
+};

--- a/na-backend/migrations/m20160731_123915_add_channel.js
+++ b/na-backend/migrations/m20160731_123915_add_channel.js
@@ -6,8 +6,7 @@ exports.up = function (db) {
         Channel.property.create({
             name: 'title',
             type: 'String'
-        });
-        Channel.property.create({
+        }, {
             name: 'key',
             type: 'String'
         });

--- a/na-backend/migrations/m20160731_125510_add_channel_to_queue.js
+++ b/na-backend/migrations/m20160731_125510_add_channel_to_queue.js
@@ -1,0 +1,17 @@
+"use strict";
+exports.name = "add channel";
+
+exports.up = function (db) {
+  db.class.get('Queue').then(Queue => {
+     Queue.property.create({
+         name: 'channel',
+         type: 'String'
+     });
+  });
+};
+
+exports.down = function (db) {
+    db.class.get('Queue').then(Queue => {
+       Queue.property.drop('channel');
+    });
+};

--- a/na-backend/test/lib/server-setup-test.js
+++ b/na-backend/test/lib/server-setup-test.js
@@ -17,10 +17,10 @@ describe('setupClients', function() {
 
         const clientInterface = setupClients();
 
-        expect(clientInterface.get().length).to.equal(0);
-        clientInterface.add(inputClient);
-        expect(clientInterface.get().length).to.equal(1);
-        expect(clientInterface.get()[0]).to.eql(inputClient);
+        expect(Object.keys(clientInterface.get())).to.eql([]);
+        clientInterface.addToChannel(inputClient, 'abcd');
+        expect(Object.keys(clientInterface.get())).to.eql(['abcd']);
+        expect(clientInterface.get()['abcd']).to.eql([inputClient]);
     });
 
     it('should provide an interface to write data to all clients', function() {
@@ -32,8 +32,8 @@ describe('setupClients', function() {
         };
 
         const clientInterface = setupClients();
-        clientInterface.add(inputClient);
-        clientInterface.writeToAll({data: 'xyz'});
+        clientInterface.addToChannel(inputClient, 'abcd');
+        clientInterface.writeToAllForChannel({data: 'xyz'}, 'abcd');
 
         expect(inputClient.res.write.calledWith({data: 'xyz'})).to.equal(true);
     });
@@ -47,9 +47,9 @@ describe('setupClients', function() {
         };
 
         const clientInterface = setupClients();
-        expect(clientInterface.count()).to.equal(0);
-        clientInterface.add(inputClient);
-        expect(clientInterface.count()).to.equal(1);
+        expect(clientInterface.count()).to.eql({});
+        clientInterface.addToChannel(inputClient, 'abcd');
+        expect(clientInterface.count()).to.eql({abcd: 1});
     });
 
     it('should provide an interface to remove clients by ip', function() {
@@ -63,14 +63,14 @@ describe('setupClients', function() {
         };
 
         const clientInterface = setupClients();
-        expect(clientInterface.count()).to.equal(0);
-        clientInterface.add(inputClient);
-        clientInterface.add(inputClient2);
-        expect(clientInterface.count()).to.equal(2);
+        expect(clientInterface.count()).to.eql({});
+        clientInterface.addToChannel(inputClient, 'abcd');
+        clientInterface.addToChannel(inputClient2, 'abcd');
+        expect(clientInterface.count()).to.eql({abcd: 2});
 
-        clientInterface.removeByIp('127.0.0.1');
-        expect(clientInterface.count()).to.equal(1);
-        expect(clientInterface.get()[0]).to.equal(inputClient2);
+        clientInterface.removeByIpFromChannel('127.0.0.1', 'abcd');
+        expect(clientInterface.count()).to.eql({abcd: 1});
+        expect(clientInterface.get()['abcd']).to.eql([inputClient2]);
     });
 });
 

--- a/na-backend/test/queries/channel-test.js
+++ b/na-backend/test/queries/channel-test.js
@@ -1,0 +1,52 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import {listChannels, createChannelQuery, deleteChannelQuery} from '../../js/queries/channel';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('listChannels', function () {
+    it('should return a list of channels', function (done) {
+        const channelList = [{'@rid': '#1:1', key: 'abcd', title: 'Default'}];
+        const db = {
+            query: sinon.stub().returns(Promise.resolve(channelList))
+        };
+
+        const results = listChannels(db);
+        expect(results).to.eventually.be.fulfilled.then(function(resultsList) {
+            expect(resultsList).to.eql([{key: 'abcd', title: 'Default'}]);
+            sinon.assert.calledWith(db.query, 'select * from Channel');
+            done();
+        });
+    });
+});
+
+describe('createChannelQuery', function() {
+    it('should create a new channel with key and title', function (done) {
+        const db = {
+            query: sinon.stub().returns(Promise.resolve())
+        };
+
+        const results = createChannelQuery(db, 'Default', 'abcd');
+        expect(results).to.eventually.be.fulfilled.then(function () {
+            sinon.assert.calledWith(db.query, 'insert into Channel (title, key) values (Default, abcd)');
+            done();
+        });
+    });
+});
+
+describe('deleteChannelQuery', function() {
+    it('should delete a channel by key', function (done) {
+        const db = {
+            query: sinon.stub().returns(Promise.resolve())
+        };
+
+        const results = deleteChannelQuery(db, 'abcd');
+        expect(results).to.eventually.be.fulfilled.then(function () {
+            sinon.assert.calledWith(db.query, 'delete vertex from Channel where key = :key', {params: {key: 'abcd'}});
+            done();
+        });
+    });
+});

--- a/na-backend/test/queries/now-playing-test.js
+++ b/na-backend/test/queries/now-playing-test.js
@@ -1,0 +1,38 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import nowPlayingQuery from '../../js/queries/now-playing';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('Now playing query', function() {
+    it('should retrieve now playing list for channel', function (done) {
+        const playingList = [{
+            title: 'Song1',
+            album: 'Album One',
+            artist: 'Artist Zero',
+            '@rid': '#1:1'
+        }];
+        const db = {
+            query: sinon.stub().returns(Promise.resolve(playingList))
+        };
+
+        const results = nowPlayingQuery(db, 'abcd');
+
+        expect(results).to.eventually.be.fulfilled.then(function(playing) {
+            sinon.assert.calledWith(db.query, 'select from Now_Playing where channel = :channel limit 1', {
+                params: {
+                    channel: 'abcd'
+                }
+            });
+            expect(playing).to.eql({
+                title: 'Song1',
+                album: 'Album One',
+                artist: 'Artist Zero'
+            })
+            done();
+        });
+    });
+});

--- a/na-backend/test/queries/queries-test.js
+++ b/na-backend/test/queries/queries-test.js
@@ -1,0 +1,101 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import {listQueueForChannel, addToChannelQueue, removeFromChannelQueue} from '../../js/queries/queue';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('listQueueForChannel', function() {
+    describe('with songs in the queue', function() {
+        it('returns list of songs', function(done) {
+            const queueResults = [
+                {id: '#1:1'},
+                {id: '#1:2'}
+            ];
+            const songResults = [
+                {title: 'Song1', id: 'abcdef', album: ['Album1'], artist: ['Artist1'], '@rid': '#2:1'},
+                {title: 'SongA', id: 'xyzwuv', album: ['Album0'], artist: ['ArtistX'], '@rid': '#2:2'}
+            ];
+
+            const query = sinon.stub();
+            query.onCall(0).returns(Promise.resolve(queueResults));
+            query.onCall(1).returns(Promise.resolve(songResults));
+            const db = {
+                query: query
+            };
+
+            const results = listQueueForChannel(db, 'channel1');
+            expect(results).to.eventually.be.fulfilled.then(function(processedSongs) {
+                sinon.assert.callCount(db.query, 2);
+                sinon.assert.calledWith(db.query, 'select * from Queue where channel = :channel', {
+                    params: {
+                        channel: 'channel1'
+                    }
+                });
+                sinon.assert.calledWith(db.query, `select *, out('Found_On').title as album, out('Found_On').out('Recorded_By').name as artist from [#1:1,#1:2]`);
+                expect(processedSongs).to.eql([
+                    {title: 'Song1', id: 'abcdef', album: 'Album1', artist: 'Artist1', rid: '#2:1'},
+                    {title: 'SongA', id: 'xyzwuv', album: 'Album0', artist: 'ArtistX', rid: '#2:2'}
+                ]);
+                done();
+            });
+        });
+    });
+
+    describe('with no songs in the queue', function() {
+        it('returns an empty array', function(done) {
+            const queueResults = [];
+
+            const query = sinon.stub();
+            query.onCall(0).returns(Promise.resolve(queueResults));
+            const db = {
+                query: query
+            };
+
+            const results = listQueueForChannel(db, 'channel1');
+            expect(results).to.eventually.be.fulfilled.then(function(processedSongs) {
+                sinon.assert.callCount(db.query, 1);
+                sinon.assert.calledWith(db.query, 'select * from Queue where channel = :channel', {
+                    params: {
+                        channel: 'channel1'
+                    }
+                });
+                expect(processedSongs).to.eql([]);
+                done();
+            });
+        });
+    });
+});
+
+describe('addToChannelQueue', function () {
+    it('runs insert query', function() {
+        const queryResults = sinon.stub();
+        const db = {
+            query: sinon.stub().returns(queryResults)
+        };
+
+        const results = addToChannelQueue(db, '#1:1', 'abcd');
+        sinon.assert.calledWith(db.query, `insert into Queue (id, channel) values (#1:1, abcd)`);
+        expect(results).to.equal(queryResults);
+    });
+});
+
+describe('removeFromChannelQueue', function () {
+    it('runs delete query', function () {
+        const queryResults = sinon.stub();
+        const db = {
+            query: sinon.stub().returns(queryResults)
+        };
+
+        const results = removeFromChannelQueue(db, '#1:1', 'abcd');
+        sinon.assert.calledWith(db.query, 'delete vertex from Queue where id = :rid and channel = :channel', {
+            params: {
+                rid: '#1:1',
+                channel: 'abcd'
+            }
+        });
+        expect(results).to.equal(queryResults);
+    });
+});

--- a/na-backend/test/routes/channel-test.js
+++ b/na-backend/test/routes/channel-test.js
@@ -1,0 +1,123 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import {getChannels, createChannel, deleteChannel} from '../../js/routes/channel';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('Channel routes', function() {
+    describe('getChannels', function() {
+        it('should have the correct url', function() {
+            const expectedUrl = '/api/channel';
+
+            expect(getChannels.url).to.equal(expectedUrl);
+        });
+
+        it('should return a function from generateHandler', function() {
+            const db = sinon.stub();
+            const listChannels = sinon.stub();
+
+            const handler = getChannels.generateHandler(db, listChannels);
+            expect(handler).to.be.a('function');
+        });
+
+        it('should return a list of channels', function(done) {
+            const channelResults = ['Channel1', 'Channel2'];
+            const listChannels = sinon.stub().returns(Promise.resolve(channelResults));
+            const db = sinon.stub();
+
+            const res = {
+                send: sinon.stub()
+            };
+
+            const handler = getChannels.generateHandler(db, listChannels);
+            const results = handler({}, res);
+
+            expect(results).to.eventually.be.fulfilled.then(function() {
+                sinon.assert.calledWith(listChannels, db);
+                sinon.assert.calledWith(res.send, JSON.stringify(channelResults));
+                done();
+            });
+        });
+    });
+
+    describe('createChannel', function() {
+        it('should have the correct url', function() {
+            const expectedUrl = '/api/channel';
+
+            expect(createChannel.url).to.equal(expectedUrl);
+        });
+
+        it('should return a function from generateHandler', function() {
+            const db = sinon.stub();
+            const create = sinon.stub();
+
+            const handler = createChannel.generateHandler(db, create);
+            expect(handler).to.be.a('function');
+        });
+
+        it('should create a channel', function(done) {
+            const db = sinon.stub();
+            const create = sinon.stub().returns(Promise.resolve());
+
+            const req = {
+                body: {
+                    title: 'Channel1'
+                }
+            };
+            const res = {
+                sendStatus: sinon.stub()
+            };
+
+            const handler = createChannel.generateHandler(db, create);
+            const results = handler(req, res);
+
+            expect(results).to.eventually.be.fulfilled.then(function() {
+                sinon.assert.calledWith(create, db, 'Channel1', sinon.match.string);
+                sinon.assert.calledWith(res.sendStatus, 200);
+                done();
+            });
+        });
+    });
+
+    describe('deleteChannel', function() {
+        it('should have the correct url', function() {
+            const expectedUrl = '/api/channel';
+
+            expect(createChannel.url).to.equal(expectedUrl);
+        });
+
+        it('should return a function from generateHandler', function() {
+            const db = sinon.stub();
+            const deleteQuery = sinon.stub();
+
+            const handler = deleteChannel.generateHandler(db, deleteQuery);
+            expect(handler).to.be.a('function');
+        });
+
+        it('should delete a channel', function(done) {
+            const db = sinon.stub();
+            const deleteQuery = sinon.stub().returns(Promise.resolve());
+
+            const req = {
+                params: {
+                    key: 'abcdef'
+                }
+            };
+            const res = {
+                sendStatus: sinon.stub()
+            };
+
+            const handler = deleteChannel.generateHandler(db, deleteQuery);
+            const results = handler(req, res);
+
+            expect(results).to.eventually.be.fulfilled.then(function() {
+                sinon.assert.calledWith(deleteQuery, db, 'abcdef');
+                sinon.assert.calledWith(res.sendStatus, 200);
+                done();
+            });
+        });
+    });
+});

--- a/na-backend/test/routes/stream-test.js
+++ b/na-backend/test/routes/stream-test.js
@@ -10,13 +10,13 @@ describe('Stream route', function() {
     describe('getStream', function() {
         beforeEach(function() {
             clients = {
-                add: sinon.stub(),
-                removeByIp: sinon.stub()
+                addToChannel: sinon.stub(),
+                removeByIpFromChannel: sinon.stub()
             };
         });
 
         it('should have correct url', function() {
-            const expectedUrl = '/api/stream';
+            const expectedUrl = '/api/stream/:channel';
 
             expect(getStream.url).to.equal(expectedUrl);
         });
@@ -32,7 +32,10 @@ describe('Stream route', function() {
 
             const inputRequest = {
                 connection: new EventEmitter(),
-                ip: '127.0.0.1'
+                ip: '127.0.0.1',
+                params: {
+                    channel: 'abcd'
+                }
             };
             const inputResponse = {
                 writeHead: sinon.stub()
@@ -47,7 +50,7 @@ describe('Stream route', function() {
                 "Connection": "close",
                 "Transfer-Encoding": "identity"
             }));
-            expect(clients.add.calledWith({ res: inputResponse, ip: '127.0.0.1' })).to.equal(true);
+            sinon.assert.calledWith(clients.addToChannel, { res: inputResponse, ip: '127.0.0.1'}, 'abcd');
         });
 
         it('should generate handler that ignores headers if already exist', function() {
@@ -55,7 +58,10 @@ describe('Stream route', function() {
 
             const inputRequest = {
                 connection: new EventEmitter(),
-                ip: '127.0.0.1'
+                ip: '127.0.0.1',
+                params: {
+                    channel: 'abcd'
+                }
             };
             const inputResponse = {
                 headers: {
@@ -76,7 +82,10 @@ describe('Stream route', function() {
 
             const inputRequest = {
                 connection: new EventEmitter(),
-                ip: '127.0.0.1'
+                ip: '127.0.0.1',
+                params: {
+                    channel: 'abcd'
+                }
             };
             const inputResponse = {
                 headers: {
@@ -89,7 +98,7 @@ describe('Stream route', function() {
 
             handler(inputRequest, inputResponse);
 
-            expect(populateQueue.called).to.be.true;
+            expect(populateQueue.calledWith('abcd')).to.be.true;
         });
 
         it('should generate handler that removes client when connection disconnects', function() {
@@ -97,7 +106,10 @@ describe('Stream route', function() {
 
             const inputRequest = {
                 connection: new EventEmitter(),
-                ip: '127.0.0.1'
+                ip: '127.0.0.1',
+                params: {
+                    channel: 'abcd'
+                }
             };
             const inputResponse = {
                 headers: {
@@ -110,9 +122,9 @@ describe('Stream route', function() {
 
             handler(inputRequest, inputResponse);
 
-            expect(clients.add.calledWith({ res: inputResponse, ip: '127.0.0.1' })).to.equal(true);
+            expect(clients.addToChannel.calledWith({ res: inputResponse, ip: '127.0.0.1' }, 'abcd')).to.equal(true);
             inputRequest.connection.emit('close');
-            expect(clients.removeByIp.calledWith(inputRequest.ip)).to.equal(true);
+            expect(clients.removeByIpFromChannel.calledWith(inputRequest.ip, 'abcd')).to.equal(true);
         });
     });
 });

--- a/na-client/js/lib/streams/create-track-response.js
+++ b/na-client/js/lib/streams/create-track-response.js
@@ -3,10 +3,11 @@ import Throttle from 'throttle';
 import createTrackStream from './create-track-stream';
 
 export default function(filesStore, sendFileData, probe) {
-    return function(trackId) {
-        console.log(trackId);
+    return function(trackRequest) {
+        console.log(trackRequest);
+        const [trackId, channel] = trackRequest.split(';');
         const track = filesStore[trackId];
-        const streamTrack = createTrackStream(track, trackId, sendFileData, Throttle);
+        const streamTrack = createTrackStream(track, trackId, sendFileData, Throttle, channel);
         probe(track, streamTrack);
     };
 }

--- a/na-client/js/lib/streams/create-track-stream.js
+++ b/na-client/js/lib/streams/create-track-stream.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import Rx from 'rx';
 
-export default function(track, trackId, sendFileData, Throttle) {
+export default function(track, trackId, sendFileData, Throttle, channel) {
     return function(err, results) {
         const trackStream = fs.createReadStream(track);
         const bps = (results.format.bit_rate / 10) * 1.2;
@@ -18,7 +18,7 @@ export default function(track, trackId, sendFileData, Throttle) {
         .subscribe(() => {
             throttledData.dispose();
             throttleEnd.dispose();
-            sendFileData(trackId);
+            sendFileData(trackId + ';' + channel);
         });
     };
 }


### PR DESCRIPTION
### Description

This PR will setup backend changes required to implement multiple channels. This will pave the way for functionality to create channels from particular artists, genres, albums or songs.
### Other required work

Blocked by #3 
### To do

To do before merge:
- [x] Create Channel in db
- [ ] Associate song in queue to a particular channel
- [x] Endpoints to create, delete channel
- [x] Update queue endpoints to show queue for a particular channel
- [ ] Update queue create and new song functions to work with multiple channels
- [ ] Setup default channel
